### PR TITLE
update liaisons and documentaion of same

### DIFF
--- a/charter-draft.html
+++ b/charter-draft.html
@@ -204,17 +204,6 @@ in	"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 					the WICG on privacy issues related to advertising.
 				</p>
 
-				<h3>
-					External Groups
-				</h3>
-				<dl>
-					<dt>
-						<span><a href="https://www.iab.org/">Internet Architecture Board</a> <a href="https://www.iab.org/activities/programs/privacy-and-security-program/">Privacy and Security Program</a></span>
-					</dt>
-					<dd>
-						<span>PING will share experiences with the IAB Privacy and Security Program which is considering systematic improvements to privacy and security in IETF standards.</span>
-					</dd>
-				</dl>
 			</div>
 			<div class="participation">
 				<h2 id="participation">
@@ -402,7 +391,7 @@ in	"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
                   31 December 2022
                 </td>
                 <td>
-                  <p>Signficant changes highlighting PING's role in horizontal review. Increased team contact time commitment to .3 FTE.</p>
+                  <p>Signficant changes highlighting PING's role in horizontal review. Removed IAB Security and Privacy program liaison, since program closed.  Removed list of specific WG liaisons, since PING expects to work with all of them now.  Listing TAG, WICG, and Web Advertising BG for liaison. Increased team contact time commitment to .3 FTE.</p>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
remove IAB sec and priv program, now closed.  say more in the history table about liaison changes.