### PR TITLE
remove cvs date stamp

### DIFF
--- a/charter-draft.html
+++ b/charter-draft.html
@@ -405,9 +405,9 @@ in	"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 			<p class="copyright">
 				<a rel="Copyright" href="/Consortium/Legal/ipr-notice#Copyright" shape="rect">Copyright</a>© 2011-2018 <a href="/" shape="rect"><acronym title="World Wide Web Consortium">W3C</acronym></a> <sup>®</sup> (<a href="https://www.csail.mit.edu/" shape="rect"><acronym title="Massachusetts Institute of Technology">MIT</acronym></a> , <a href="http://www.ercim.org/" shape="rect"><acronym title="European Research Consortium for Informatics and Mathematics">ERCIM</acronym></a> , <a href="http://www.keio.ac.jp/" shape="rect">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.
 			</p>
-			<p>
+		<!--	<p>
 				$Date: 2018/03/01 20:04:51 $
-			</p>
+			</p>-->
 		</div>
 	</body>
 </html>


### PR DESCRIPTION
GH doesn't update it, so it keeps getting more and more stale.